### PR TITLE
Make the Unison working directory configurable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,14 @@ RUN apt-get update -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
 
-# Set default Unison version
+# Set default Unison configuration
 ENV UNISON_VERSION=2.48.3
+ENV UNISON_WORKING_DIR=/unison
 
 # Set working directory to be the home directory
 WORKDIR /root
 
 # Setup unison to run as a service
-VOLUME /unison
+VOLUME $UNISON_WORKING_DIR
 COPY unison-run.sh /etc/service/unison/run
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The docker image is available on Docker Hub:
 First, you can launch a volume container exposing a volume with Unison.
 
 ```bash
-$ CID=$(docker run -d -p 5000:5000 -e UNISON_VERSION=2.48.3 leighmcculloch/unison)
+$ CID=$(docker run -d -p 5000:5000 -e UNISON_VERSION=2.48.3 -e UNISON_WORKING_DIR=/unison leighmcculloch/unison)
 ```
 
 You can then sync a local folder to `/unison` in the container with:
@@ -41,6 +41,7 @@ unison:
   image: leighmcculloch/unison  
   environment:  
     - UNISON_VERSION=2.48.3  
+    - UNISON_WORKING_DIR=/unison  
   ports:  
     - "5000:5000"
 ```

--- a/unison-run.sh
+++ b/unison-run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export HOME=/root
-cd /unison
+cd $UNISON_WORKING_DIR
 exec unison-$UNISON_VERSION -socket 5000 >>/var/log/unison.log 2>&1


### PR DESCRIPTION
### What

Make the directory that gets synced configurable, instead of hardcoding it as `/unison`.
### Why

@smith64fx suggested this change in #5, so that they could could change it for their use cases. Makes sense to make this available as there's no reason not to and doesn't increase setup with a default still set to `/unison`.
