### PR TITLE
Support more flexible, faster development cycles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update -y \
 ENV UNISON_VERSION=2.48.3
 ENV UNISON_WORKING_DIR=/unison
 
+COPY unison-link.sh .
+RUN ./unison-link.sh
+
 # Set working directory to be the home directory
 WORKDIR /root
 

--- a/unison-install.sh
+++ b/unison-install.sh
@@ -6,7 +6,9 @@ do
   cd /tmp/unison
   tar -zxvf $UNISON_TAR_GZ
   UNISON_RELEASE=${UNISON_TAR_GZ%.tar.gz}
+  UNISON_VERSION=${UNISON_RELEASE#unison-}
   cd $UNISON_RELEASE
   make UISTYLE=text
   cp unison /bin/$UNISON_RELEASE
+  cp unison-fsmonitor /bin/unison-fsmonitor-$UNISON_VERSION
 done

--- a/unison-link.sh
+++ b/unison-link.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ln -s /bin/unison-fsmonitor-$UNISON_VERSION /bin/unison-fsmonitor


### PR DESCRIPTION
There are two small commits here with detailed messages. They add "-repeat watch" support and allow configuring the replica path. This combination enhances the ease of use and performance for development.

Here is a handy shell alias to start syncing from the current directory to an active Docker machine instance. This does require unison-fsmonitor to be set up on the client as well.

```
function dsync() {
    MACHINE=""
    if [[ -n $1 ]]; then
        MACHINE=$1
    else
        MACHINE="$(dm active)"
    fi

    HOST="$(dm ip $MACHINE)"
    PORT=5000
    if [[ -n $2 ]]; then
        PORT=$2
    fi

    unison . socket://$HOST:$PORT/ -ignore 'Path .git' -ignore 'Path tmp' -auto -batch -prefer . -repeat watch -fastcheck true
}
```
